### PR TITLE
expose webview onWebResourceError callback

### DIFF
--- a/lib/flutter_echarts.dart
+++ b/lib/flutter_echarts.dart
@@ -28,6 +28,7 @@ class Echarts extends StatefulWidget {
     this.captureHorizontalGestures = false,
     this.captureVerticalGestures = false,
     this.onLoad,
+    this.onWebResourceError,
     this.reloadAfterInit = false
   }) : super(key: key);
 
@@ -48,6 +49,8 @@ class Echarts extends StatefulWidget {
   final bool captureVerticalGestures;
 
   final void Function(WebViewController)? onLoad;
+
+  final void Function(WebViewController, Exception)? onWebResourceError;
 
   final bool reloadAfterInit;
 
@@ -167,6 +170,11 @@ class _EchartsState extends State<Echarts> {
           }
           // --- FIX_BLINK ---
           init();
+        },
+        onWebResourceError: (e) {
+          if (widget.onWebResourceError != null) {
+            widget.onWebResourceError!(_controller!, Exception(e));
+          }
         },
         javascriptChannels: <JavascriptChannel>[
           JavascriptChannel(


### PR DESCRIPTION
try resolve https://github.com/entronad/flutter_echarts/issues/129 properly

> Is there a way to catch the Exception and call reload() for the webview render properly?

The blank issue may related to https://github.com/flutter/flutter/issues/61795

>I think this issue is because of a more general issue with the design of the framework itself. When the state of a widget changes, flutter doesn't change the widget, but discards it and makes a new one. This is fine for lightweight text widgets and such, but for webviews it means creating and destroying a webview every time the page is scrolled potentially.

I am using flutter_echarts plugin in my project, and facing blank issue too. It happen only on ios in practice(but may due to ios webview is resource heavy; more webview/echarts in a screen may increase the error rate) 
For plugin side, currently best work-around maybe expose a callback when error for users to reload.